### PR TITLE
Add market page and progress tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Frontend Development Progress
+
+## Checklist
+
+- [x] Base React + Tailwind setup
+- [x] Core navigation layout
+- [x] Sniper configuration UI
+- [x] Transaction history screen
+- [x] Analytics dashboard
+- [ ] Market overview page
+- [ ] Token info/search integration
+- [ ] Wallet integration polish
+
+## Feature Status
+
+| Feature | Status |
+| --- | --- |
+| Dashboard with balances | Completed |
+| Sniper configuration | Completed |
+| Transactions log | Completed |
+| Analytics charts | Completed |
+| Market data view | In Progress |
+| Token lookup | Planned |
+| Settings panel | Completed |
+
+## Current Issues / Blockers
+
+- No live API endpoints for tokenService yet, using mock data.
+- Linting fails in environments without dependencies installed.
+
+## API / Function Notes
+
+- `getTokenInfo(address)` in `src/lib/tokenService.ts` should feed a token detail component.
+- `useMarketData()` from `src/lib/marketData.ts` powers the market overview page.
+- `startSnipe(config)` from `src/lib/sniperService.ts` is triggered from SniperConfig page.
+- Transaction management via `src/lib/transactionStore.ts` already wired to Transactions page.
+

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Crosshair, History, LineChart, Settings as SettingsIcon } from 'lucide-react';
+import { LayoutDashboard, Crosshair, History, LineChart, Activity, Settings as SettingsIcon } from 'lucide-react';
 import WalletConnect from './WalletConnect';
 import { ThemeToggle } from './ThemeToggle';
 
@@ -15,6 +15,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     { name: 'Dashboard', href: '/', icon: LayoutDashboard },
     { name: 'Sniper', href: '/sniper', icon: Crosshair },
     { name: 'Transactions', href: '/transactions', icon: History },
+    { name: 'Market', href: '/market', icon: Activity },
     { name: 'Analytics', href: '/analytics', icon: LineChart },
     { name: 'Settings', href: '/settings', icon: SettingsIcon },
   ];

--- a/src/pages/Market.tsx
+++ b/src/pages/Market.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useMarketData } from '../lib/marketData';
+
+const Market: React.FC = () => {
+  const { tokens, loading, error } = useMarketData();
+
+  return (
+    <div className="flex-1 p-2 sm:p-4 md:p-6">
+      <div className="max-w-7xl mx-auto">
+        <div className="mb-4 sm:mb-6">
+          <h1 className="text-xl sm:text-2xl font-bold gradient-text">Market Overview</h1>
+          <p className="text-xs sm:text-sm text-muted-foreground mt-1">Top Solana tokens by volume</p>
+        </div>
+        <div className="glass rounded-xl overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left">
+                <th className="px-3 py-2">Token</th>
+                <th className="px-3 py-2 text-right">Price</th>
+                <th className="px-3 py-2 text-right">24h %</th>
+                <th className="px-3 py-2 text-right">24h Volume</th>
+                <th className="px-3 py-2 text-right">Liquidity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tokens.map((t) => (
+                <tr key={t.address} className="border-b border-border last:border-b-0">
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    <div className="font-medium">{t.symbol}</div>
+                    <div className="text-muted-foreground text-xs">{t.name}</div>
+                  </td>
+                  <td className="px-3 py-2 text-right">${parseFloat(t.priceUsd).toFixed(4)}</td>
+                  <td
+                    className={`px-3 py-2 text-right ${t.priceChange?.h24 >= 0 ? 'text-green-500' : 'text-red-500'}`}
+                  >
+                    {t.priceChange?.h24 >= 0 ? '+' : ''}{t.priceChange?.h24.toFixed(2)}%
+                  </td>
+                  <td className="px-3 py-2 text-right">${(t.volume?.h24 || 0).toLocaleString()}</td>
+                  <td className="px-3 py-2 text-right">${(t.liquidity?.usd || 0).toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {tokens.length === 0 && !loading && (
+            <div className="p-4 text-center text-muted-foreground">No data</div>
+          )}
+        </div>
+        {loading && <div className="text-center py-6">Loading...</div>}
+        {error && <div className="text-center text-red-500 py-6">{error}</div>}
+      </div>
+    </div>
+  );
+};
+
+export default Market;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -5,6 +5,7 @@ import SniperConfig from './pages/SniperConfig';
 import Transactions from './pages/Transactions';
 import Analytics from './pages/Analytics';
 import Settings from './pages/Settings';
+import Market from './pages/Market';
 
 const router = createBrowserRouter([
   {
@@ -29,6 +30,12 @@ const router = createBrowserRouter([
     path: '/analytics',
     element: <Layout>
       <Analytics />
+    </Layout>,
+  },
+  {
+    path: '/market',
+    element: <Layout>
+      <Market />
     </Layout>,
   },
   {


### PR DESCRIPTION
## Summary
- create `Market` page showing top tokens via `useMarketData`
- update navigation and router to include market view
- add development progress notes in `AGENTS.md`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844bb59724483248d56e42c1b84fa30