### PR TITLE
Add token search page and update progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Frontend Development Progress
+
+## Checklist
+
+- [x] Base React + Tailwind setup
+- [x] Core navigation layout
+- [x] Sniper configuration UI
+- [x] Transaction history screen
+- [x] Analytics dashboard
+- [x] Market overview page
+- [ ] Token info/search integration
+- [ ] Wallet integration polish
+
+## Feature Status
+
+| Feature | Status |
+| --- | --- |
+| Dashboard with balances | Completed |
+| Sniper configuration | Completed |
+| Transactions log | Completed |
+| Analytics charts | Completed |
+| Market data view | Completed |
+| Token lookup | In Progress |
+| Settings panel | Completed |
+
+## Current Issues / Blockers
+
+- No live API endpoints for tokenService yet, using mock data.
+- Linting fails in environments without dependencies installed.
+
+## API / Function Notes
+
+- `getTokenInfo(address)` in `src/lib/tokenService.ts` should feed a token detail component.
+- `useMarketData()` from `src/lib/marketData.ts` powers the market overview page.
+- `startSnipe(config)` from `src/lib/sniperService.ts` is triggered from SniperConfig page.
+- Transaction management via `src/lib/transactionStore.ts` already wired to Transactions page.
+

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Crosshair, History, LineChart, Settings as SettingsIcon } from 'lucide-react';
+import { LayoutDashboard, Crosshair, History, LineChart, Activity, Search, Settings as SettingsIcon } from 'lucide-react';
 import WalletConnect from './WalletConnect';
 import { ThemeToggle } from './ThemeToggle';
 
@@ -15,6 +15,8 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     { name: 'Dashboard', href: '/', icon: LayoutDashboard },
     { name: 'Sniper', href: '/sniper', icon: Crosshair },
     { name: 'Transactions', href: '/transactions', icon: History },
+    { name: 'Market', href: '/market', icon: Activity },
+    { name: 'Tokens', href: '/tokens', icon: Search },
     { name: 'Analytics', href: '/analytics', icon: LineChart },
     { name: 'Settings', href: '/settings', icon: SettingsIcon },
   ];

--- a/src/pages/Market.tsx
+++ b/src/pages/Market.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useMarketData } from '../lib/marketData';
+
+const Market: React.FC = () => {
+  const { tokens, loading, error } = useMarketData();
+
+  return (
+    <div className="flex-1 p-2 sm:p-4 md:p-6">
+      <div className="max-w-7xl mx-auto">
+        <div className="mb-4 sm:mb-6">
+          <h1 className="text-xl sm:text-2xl font-bold gradient-text">Market Overview</h1>
+          <p className="text-xs sm:text-sm text-muted-foreground mt-1">Top Solana tokens by volume</p>
+        </div>
+        <div className="glass rounded-xl overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left">
+                <th className="px-3 py-2">Token</th>
+                <th className="px-3 py-2 text-right">Price</th>
+                <th className="px-3 py-2 text-right">24h %</th>
+                <th className="px-3 py-2 text-right">24h Volume</th>
+                <th className="px-3 py-2 text-right">Liquidity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tokens.map((t) => (
+                <tr key={t.address} className="border-b border-border last:border-b-0">
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    <div className="font-medium">{t.symbol}</div>
+                    <div className="text-muted-foreground text-xs">{t.name}</div>
+                  </td>
+                  <td className="px-3 py-2 text-right">${parseFloat(t.priceUsd).toFixed(4)}</td>
+                  <td
+                    className={`px-3 py-2 text-right ${t.priceChange?.h24 >= 0 ? 'text-green-500' : 'text-red-500'}`}
+                  >
+                    {t.priceChange?.h24 >= 0 ? '+' : ''}{t.priceChange?.h24.toFixed(2)}%
+                  </td>
+                  <td className="px-3 py-2 text-right">${(t.volume?.h24 || 0).toLocaleString()}</td>
+                  <td className="px-3 py-2 text-right">${(t.liquidity?.usd || 0).toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {tokens.length === 0 && !loading && (
+            <div className="p-4 text-center text-muted-foreground">No data</div>
+          )}
+        </div>
+        {loading && <div className="text-center py-6">Loading...</div>}
+        {error && <div className="text-center text-red-500 py-6">{error}</div>}
+      </div>
+    </div>
+  );
+};
+
+export default Market;

--- a/src/pages/TokenSearch.tsx
+++ b/src/pages/TokenSearch.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { Input } from '../components/ui/input';
+import { Button } from '../components/ui/button';
+import { getTokenInfo, TokenInfo } from '../lib/tokenService';
+
+const TokenSearch: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const [token, setToken] = useState<TokenInfo | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = async () => {
+    if (!query) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const info = await getTokenInfo(query.trim());
+      if (info) {
+        setToken(info);
+      } else {
+        setToken(null);
+        setError('Token not found');
+      }
+    } catch (err) {
+      console.error(err);
+      setError('Failed to fetch token info');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex-1 p-2 sm:p-4 md:p-6">
+      <div className="max-w-xl mx-auto space-y-4">
+        <div>
+          <h1 className="text-xl sm:text-2xl font-bold gradient-text">Token Search</h1>
+          <p className="text-xs sm:text-sm text-muted-foreground mt-1">Lookup token details by address</p>
+        </div>
+        <div className="flex gap-2">
+          <Input
+            placeholder="Enter token address"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="flex-1"
+          />
+          <Button onClick={handleSearch} disabled={loading || !query}>
+            Search
+          </Button>
+        </div>
+        {loading && <div className="text-center">Loading...</div>}
+        {error && <div className="text-center text-red-500">{error}</div>}
+        {token && (
+          <div className="glass rounded-xl p-4 space-y-2">
+            <div className="font-semibold text-lg">{token.name} ({token.symbol})</div>
+            <div className="text-sm text-muted-foreground break-words">{token.address}</div>
+            <div className="text-sm">Decimals: {token.decimals}</div>
+            <div className="text-sm">Total Supply: {token.totalSupply.toLocaleString()}</div>
+            {token.price !== undefined && (
+              <div className="text-sm">Price: ${token.price.toFixed(4)}</div>
+            )}
+            {token.marketcap !== undefined && (
+              <div className="text-sm">Market Cap: ${token.marketcap.toLocaleString()}</div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TokenSearch;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -5,6 +5,8 @@ import SniperConfig from './pages/SniperConfig';
 import Transactions from './pages/Transactions';
 import Analytics from './pages/Analytics';
 import Settings from './pages/Settings';
+import Market from './pages/Market';
+import TokenSearch from './pages/TokenSearch';
 
 const router = createBrowserRouter([
   {
@@ -29,6 +31,18 @@ const router = createBrowserRouter([
     path: '/analytics',
     element: <Layout>
       <Analytics />
+    </Layout>,
+  },
+  {
+    path: '/market',
+    element: <Layout>
+      <Market />
+    </Layout>,
+  },
+  {
+    path: '/tokens',
+    element: <Layout>
+      <TokenSearch />
     </Layout>,
   },
   {


### PR DESCRIPTION
## Summary
- add TokenSearch page with address lookup using `getTokenInfo`
- extend router and navigation to include TokenSearch page
- mark Market page completed in progress tracker

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844bb59724483248d56e42c1b84fa30